### PR TITLE
Fix for ScheduledTask - existing Job, and using Credentials

### DIFF
--- a/DSCResources/StackExchange_ScheduledTask/StackExchange_ScheduledTask.psm1
+++ b/DSCResources/StackExchange_ScheduledTask/StackExchange_ScheduledTask.psm1
@@ -210,7 +210,6 @@ function Set-TargetResource
                 $JobTriggerParameters.DaysOfWeek = $DaysOfWeek
             }
         }
-        #$JobParameters.Trigger = New-JobTrigger @JobTriggerParameters
 
         ### If the job exists, then remove it before adding again
         if ($Job)


### PR DESCRIPTION
Ran into two issues using this resource:
1. The resource would fail in the LCM with access-denied, so I plumbed in the Credential parameter and used New-PSSession, like in Test-TargetResource
2. The Set-TargetResource would fail if the ScheduledTask already exists.  I would usually do a property-by-property diff but took the lazy solution to just clobber the existing ScheduledTask, allowing the new one to be created.
