### PR TITLE
Added ability to import certificates of other types than PKCS12/PFX

### DIFF
--- a/DSCResources/StackExchange_CertificateStore/StackExchange_CertificateStore.psm1
+++ b/DSCResources/StackExchange_CertificateStore/StackExchange_CertificateStore.psm1
@@ -22,7 +22,11 @@ function Get-TargetResource
         [parameter()]
         [ValidateSet('Present','Absent')]
         [string]
-        $Ensure = 'Present'
+        $Ensure = 'Present',
+		[parameter()]
+		[ValidateSet('PKCS12','PKCS7','X509')]
+		[string]
+		$Format = 'PKCS12'
     )
     
     #Needs to return a hashtable that returns the current
@@ -70,7 +74,11 @@ function Set-TargetResource
         [parameter()]
         [ValidateSet('Present','Absent')]
         [string]
-        $Ensure = 'Present'
+        $Ensure = 'Present',
+		[parameter()]
+		[ValidateSet('PKCS12','PKCS7','X509')]
+		[string]
+		$Format = 'PKCS12'
     )
 
     $CertificateBaseLocation = "cert:\$Location\$Store"
@@ -78,7 +86,15 @@ function Set-TargetResource
     if ($Ensure -like 'Present')
     {        
         Write-Verbose "Adding $path to $CertificateBaseLocation."
-        Import-PfxCertificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path 
+		
+		if ($Format -eq 'PKCS12')
+		{
+			Import-PfxCertificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path 
+		}
+		else
+		{
+			Import-Certificate -CertStoreLocation $CertificateBaseLocation -FilePath $Path
+		}
     }
     else
     {
@@ -110,7 +126,11 @@ function Test-TargetResource
         [parameter()]
         [ValidateSet('Present','Absent')]
         [string]
-        $Ensure = 'Present'
+        $Ensure = 'Present',
+		[parameter()]
+		[ValidateSet('PKCS12','PKCS7','X509')]
+		[string]
+		$Format = 'PKCS12'
     )
 
     $IsValid = $false

--- a/DSCResources/StackExchange_CertificateStore/StackExchange_CertificateStore.schema.mof
+++ b/DSCResources/StackExchange_CertificateStore/StackExchange_CertificateStore.schema.mof
@@ -6,6 +6,7 @@ class StackExchange_CertificateStore : OMI_BaseResource
 [write,ValueMap{"LocalMachine", "CurrentUser"},Values{"LocalMachine", "CurrentUser"}] string Location;
 [write] string Store;
 [write,ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] string Ensure;
+[write,ValueMap{"PKCS12", "PKCS7", "X509"},Values{"PKCS12", "PKCS7", "X509"}] string Format;
 };
 
 


### PR DESCRIPTION
The Import-PfxCertificate only allows importing PKCS12-encoded certificates (often with its private key). Windows however allows certificates to be exported in several formats: PKCS12, PKCS7 and X509 (DER and Base64 encoded).

I have added an additional parameter `Format` to the resource to allow the user to specify which format the certificate is in, and some additional logic to use the Import-Certificate method for all formats except PKCS12. Available formats are `PKCS12`, `PKCS7` and `X509`. The resource will default to the `PKCS12` format for backwards compatibility.

I first considered basing the logic solely on the file extension of the FilePath, but reconsidered since in my experience there are a lot of variations on certificate file extensions: .cer, .cert, .crt, .pfx, .p12.